### PR TITLE
Add .whitesource file

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,7 +1,7 @@
 {
-  "settingsInheritedFrom": "benrieger-mend/whitesource-config@main",
-  "scanSettings": {
-    "baseBranches": ["main"]
-  }
+"settingsInheritedFrom": "benrieger-mend/whitesource-config@main",
+"scanSettings": {
+"baseBranches": ["main"]
 }
-        
+}
+    


### PR DESCRIPTION

Added .whitesource file with base branch main, for scanning 'Mend On Mend'.
This configuration file is inheriting from https://github.com/benrieger-mend/whitesource-config/blob/main/repo-config.json
The repo-config.json is the global organization config, for now it's configured to scan SCA only and with renovate OFF Won't open PR's).
You can overwrite configuration for this specific repo and add more scanning features using these DOCS:
https://mend-io.atlassian.net/wiki/spaces/MEND/pages/2829517381/Configure+Mend+for+GitHub+Enterprise+for+SCA
https://mend-io.atlassian.net/wiki/spaces/MEND/pages/2829517769/Configure+Mend+for+GitHub+Enterprise+for+SAST
https://mend-io.atlassian.net/wiki/spaces/MEND/pages/2829518239/Configure+Mend+for+GitHub+Enterprise+for+IaC
    